### PR TITLE
Correctly Use uri() Instead of uid() to Identify Pages & Build Paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ This plugin sets a robots file to `/robots.txt` as a kirby route. There is no ac
 The robots file can be configured via Kirby’s config file `/site/config/config.php`.
 
 ### Ignore Pages
-Ignore pages by uid. (array) *Default: error*
+Ignore specific pages by URI - example: 'blog/my-article'. (array) *Default: error*
 ```
 c::set( 'robots.ignore.pages', array('error') );
 ```

--- a/kirby-robots.php
+++ b/kirby-robots.php
@@ -3,7 +3,7 @@
  * -------------------------------------------------------------------
  * Plugin Name: Robots
  * Description: robots.txt for Kirby Websites.
- * @version    1.0.0
+ * @version    1.0.1
  * @author     Patrick Schumacher <hello@thepoddi.com>
  * @link       https://github.com/ThePoddi/kirby-robots
  * @license    MIT
@@ -27,10 +27,10 @@ kirby()->routes(
         // disallow crawling for some pages
         foreach( site()->index() as $p ) :
           if (
-            in_array( $p->uid(), $ignorePages ) || // ignore pages defined in config
+            in_array( $p->uri(), $ignorePages ) || // ignore pages defined in config
             in_array( $p->intendedTemplate(), $ignoreTemplates ) || // ignore templates defined in config
             ( $ignoreInvisible === true && $p->isInvisible() ) // ignore invisible pages
-          ) $robots .= 'Disallow: /' . $p->uid() . "\n";
+          ) $robots .= 'Disallow: /' . $p->uri() . "\n";
         endforeach;
 
         // sitemap location


### PR DESCRIPTION
Kirby's uid() function cannot be used to uniquely identify pages, and it does not reflect the subpath of a page - that is the 'uri()' function. This fixes the issues pointed out in Issue #1.